### PR TITLE
Fix CIC hook in repay borrow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,44 @@
+## Description
+
+- Please include a summary of the change and which issue is fixed.
+- Describe your solution if complex.
+- List any dependencies that are required for this change.
+- @mention anyone who is responsible for reviewing.
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+## How Has This Been Tested?
+
+Please describe the manual or automatic tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration if it's unique.
+
+- [ ] Test A
+- [ ] Test B
+
+**Test Configuration**:
+* Please list any specific environments if unique.
+
+## Screenshots of Test Results
+
+Please provide screenshots of your test results here.
+
+## Checklist:
+
+- [ ] Commented in hard-to-understand areas
+- [ ] Updated documentation
+- [ ] ESLint or other linter shows no new warnings
+- [ ] New and existing unit tests pass locally
+- [ ] New unit tests have been written and performed. (Please remove if not relevant)
+- [ ] New E2E tests have been written and performed. (Please remove if not relevant)
+
+## TODOs
+
+Any todos left or discussion details should be included here.

--- a/contracts/AToken.sol
+++ b/contracts/AToken.sol
@@ -987,7 +987,7 @@ contract AToken is ATokenInterface, Exponential, TokenErrorReporter {
         // unused function
         // comptroller.repayBorrowVerify(address(this), payer, borrower, vars.actualRepayAmount, vars.borrowerIndex);
 
-        handleActionAfter(false, payer, payer);
+        handleActionAfter(false, borrower, borrower);
 
         return (uint(Error.NO_ERROR), vars.actualRepayAmount);
     }


### PR DESCRIPTION
## Description

- The problem is that when liquidation occurs, the borrower's debt is reduced, but it does not affect the states of the CIC contract(ARS rewarder contract) so the borrower's reward would remain the same.
- Fixed hook call parameters from liquidator address to borrower address in repay borrow function.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

It has tested at a liquidation test case of staking contract repo.

## Checklist:

- [ ] Commented in hard-to-understand areas
- [ ] Updated documentation
- [x] ESLint or other linter shows no new warnings
- [x] New and existing unit tests pass locally
- [x] New unit tests have been written and performed.

## TODOs

- After this PR is merged, need to upgrade the implementation of the aUSDT, aUSDC, and aWETH proxy contracts.
